### PR TITLE
Add line breaks on NextRun info

### DIFF
--- a/inc/class-page-jobs.php
+++ b/inc/class-page-jobs.php
@@ -275,18 +275,18 @@ class BackWPup_Page_Jobs extends WP_List_Table {
 		}
 		if ( BackWPup_Option::get( $item, 'activetype' ) == 'wpcron' ) {
 			if ( $nextrun = wp_next_scheduled( 'backwpup_cron', array( 'id' => $item ) ) + ( get_option( 'gmt_offset' ) * 3600 )  ) {
-				$r .= '<span title="' . sprintf( __( 'Cron: %s','backwpup'),BackWPup_Option::get( $item, 'cron' ) ). '">' . sprintf( __( '%1$s at %2$s by WP-Cron', 'backwpup' ) , date_i18n( get_option( 'date_format' ), $nextrun, TRUE ) , date_i18n( get_option( 'time_format' ), $nextrun, TRUE ) ) . '</span>';
+				$r .= '<span title="' . sprintf( __( 'Cron: %s','backwpup'),BackWPup_Option::get( $item, 'cron' ) ). '">' . sprintf( __( '%1$s at %2$s by WP-Cron', 'backwpup' ) , date_i18n( get_option( 'date_format' ), $nextrun, TRUE ) , date_i18n( get_option( 'time_format' ), $nextrun, TRUE ) ) . '</span><br />';
 			} else {
-				$r .= __( 'Not scheduled!', 'backwpup' );
+				$r .= __( 'Not scheduled!', 'backwpup' ).'<br />';
 			}
 		}
 		if ( BackWPup_Option::get( $item, 'activetype' ) == 'easycron' ) {
 			$easycron_status = BackWPup_EasyCron::status( $item );
 			if ( !empty( $easycron_status ) ) {
 				$nextrun = BackWPup_Cron::cron_next( $easycron_status[ 'cron_expression' ] ) + ( get_option( 'gmt_offset' ) * 3600 );
-				$r .= '<span title="' . sprintf( __( 'Cron: %s','backwpup'), $easycron_status[ 'cron_expression' ] ). '">' . sprintf( __( '%1$s at %2$s by EasyCron', 'backwpup' ) , date_i18n( get_option( 'date_format' ), $nextrun, TRUE ) , date_i18n( get_option( 'time_format' ), $nextrun, TRUE ) ) . '</span>';
+				$r .= '<span title="' . sprintf( __( 'Cron: %s','backwpup'), $easycron_status[ 'cron_expression' ] ). '">' . sprintf( __( '%1$s at %2$s by EasyCron', 'backwpup' ) , date_i18n( get_option( 'date_format' ), $nextrun, TRUE ) , date_i18n( get_option( 'time_format' ), $nextrun, TRUE ) ) . '</span><br />';
 			} else {
-				$r .= __( 'Not scheduled!', 'backwpup' );
+				$r .= __( 'Not scheduled!', 'backwpup' ).'<br />';
 			}
 		}
 		else {


### PR DESCRIPTION
The "Inactive" is currently side by side to "by WP-Cron", like this: "by WP-CronInactive", not legillible.
Added line break to every possible string that appears before the "Inactive".