### PR TITLE
Cleanup again, after importing old strings from Pro

### DIFF
--- a/inc/class-mysqldump.php
+++ b/inc/class-mysqldump.php
@@ -439,11 +439,11 @@ class BackWPup_MySQLDump {
 	public function dump_table( $table, $start = 0, $length = 0 ) {
 
 		if ( ! is_numeric( $start ) ) {
-			throw new BackWPup_MySQLDump_Exception( sprintf( __( 'Start for table backup is not correctly set: %1$s ', 'backwpup' ), $start ) );
+			throw new BackWPup_MySQLDump_Exception( sprintf( __( 'Start for table backup is not correctly set: %1$s', 'backwpup' ), $start ) );
 		}
 
 		if ( ! is_numeric( $length ) ) {
-			throw new BackWPup_MySQLDump_Exception( sprintf( __( 'Length for table backup is not correctly set: %1$s ', 'backwpup' ), $length ) );
+			throw new BackWPup_MySQLDump_Exception( sprintf( __( 'Length for table backup is not correctly set: %1$s', 'backwpup' ), $length ) );
 		}
 
 		$done_records = 0;


### PR DESCRIPTION
This cleanup was already made in https://github.com/inpsyde/backwpup/commit/9603ce35bfb1c3ddabdd7fc3e342b56b15a36020 and then reverted in the last import from Pro version in https://github.com/inpsyde/backwpup/commit/02bb176ab44c8263f77a9f13ad9a1f02e82d79d0.

I believe this is was just a mistake, feel free to close this if it was this merge was really intended.