### PR TITLE
fix url google cloud storage

### DIFF
--- a/vendor/Aws/Common/Resources/public-endpoints.php
+++ b/vendor/Aws/Common/Resources/public-endpoints.php
@@ -74,6 +74,15 @@ return array(
         ),
         'sa-east-1/s3' => array(
             'endpoint' => 's3-{region}.amazonaws.com'
+        ),
+        'google-storage/*' => array(
+            'endpoint' => 'storage.googleapis.com'
+        ),
+        'google-storage-us/*' => array(
+            'endpoint' => 'storage.googleapis.com'
+        ),
+        'google-storage-asia/*' => array(
+            'endpoint' => 'storage.googleapis.com'
         )
     )
 );


### PR DESCRIPTION
fix to make Google Cloud Storage work again after 3.4.5 update