### PR TITLE
Fix Scaleway AMS region

### DIFF
--- a/inc/class-s3-destination.php
+++ b/inc/class-s3-destination.php
@@ -162,6 +162,7 @@ class BackWPup_S3_Destination
                 ),
                 'scaleway-ams' => array(
                     'label' => __('Scaleway: AMS', 'backwpup'),
+                    'region' => 'nl-ams',
                     'endpoint' => 'https://s3.nl-ams.scw.cloud',
                 ),
             )


### PR DESCRIPTION
I was getting an error with scaleway s3 configuration.
The parameter "region" is required.