### PR TITLE
Fix S3 path-style option

### DIFF
--- a/inc/class-destination-s3.php
+++ b/inc/class-destination-s3.php
@@ -20,7 +20,7 @@ class BackWPup_Destination_S3 extends BackWPup_Destinations {
         return [
             's3base_url' => '',
             's3base_multipart' => true,
-            's3base_pathstyle' => false,
+            's3base_pathstylebucket' => false,
             's3base_version' => 'latest',
             's3base_signature' => 'v4',
             's3accesskey' => '',
@@ -130,12 +130,12 @@ class BackWPup_Destination_S3 extends BackWPup_Destinations {
                                         </legend>
                                         <label for="s3base_multipart">
                                             <input name="s3base_multipart" type="checkbox"
-                                                   checked="checked" value="<?= !empty(
+                                                   value="1" <?= !empty(
                                             BackWPup_Option::get(
                                                 $jobid,
                                                 's3base_multipart'
                                             )
-                                            ) ? '1' : '' ?>">
+                                            ) ? 'checked="checked"' : '' ?>>
                                             <?php esc_html_e(
                                                 'Destination supports multipart',
                                                 'backwpup'
@@ -159,12 +159,12 @@ class BackWPup_Destination_S3 extends BackWPup_Destinations {
                                         <label
                                             for="s3base_pathstylebucket">
                                             <input name="s3base_pathstylebucket" type="checkbox"
-                                                   value="<?= !empty(
+                                                   value="1" <?= !empty(
                                                    BackWPup_Option::get(
                                                        $jobid,
                                                        's3base_pathstylebucket'
-                                                   ) ? '1' : ''
-                                                   ) ?>">
+                                                   )
+                                                   ) ? 'checked="checked"' : '' ?>>
                                             <?php esc_html_e(
                                                 'Destination provides only Pathstyle buckets',
                                                 'backwpup'
@@ -572,8 +572,8 @@ class BackWPup_Destination_S3 extends BackWPup_Destinations {
         );
         BackWPup_Option::update(
             $jobid,
-            's3base_pathstyle',
-            isset($_POST['s3base_pathstyle']) ? '1' : ''
+            's3base_pathstylebucket',
+            isset($_POST['s3base_pathstylebucket']) ? '1' : ''
         );
         BackWPup_Option::update(
             $jobid,
@@ -1110,11 +1110,11 @@ class BackWPup_Destination_S3 extends BackWPup_Destinations {
 						s3bucketselected: $( 'input[name="s3bucketselected"]' ).val(),
 						s3base_url      : $( 'input[name="s3base_url"]' ).val(),
 						s3region        : $( '#s3region' ).val(),
-						s3base_region      : $( 'input[name="s3base_region"]' ).val(),
-						s3base_version      : $( 'input[name="s3base_version"]' ).val(),
-						s3base_signature      : $( 'input[name="s3base_signature"]' ).val(),
-						s3base_multipart      : $( 'input[name="s3base_multipart"]' ).is(':checked'),
-						s3base_pathstyle      : $( 'input[name="s3base_pathstyle"]' ).is(':checked'),
+						s3base_region          : $( 'input[name="s3base_region"]' ).val(),
+						s3base_version         : $( 'input[name="s3base_version"]' ).val(),
+						s3base_signature       : $( 'input[name="s3base_signature"]' ).val(),
+						s3base_multipart       : $( 'input[name="s3base_multipart"]' ).is(':checked'),
+						s3base_pathstylebucket : $( 'input[name="s3base_pathstylebucket"]' ).is(':checked'),
 						_ajax_nonce     : $( '#backwpupajaxnonce' ).val()
 					};
 					$.post( ajaxurl, data, function ( response ) {

--- a/inc/class-destination-s3.php
+++ b/inc/class-destination-s3.php
@@ -130,12 +130,11 @@ class BackWPup_Destination_S3 extends BackWPup_Destinations {
                                         </legend>
                                         <label for="s3base_multipart">
                                             <input name="s3base_multipart" type="checkbox"
-                                                   value="1" <?= !empty(
-                                            BackWPup_Option::get(
-                                                $jobid,
-                                                's3base_multipart'
-                                            )
-                                            ) ? 'checked="checked"' : '' ?>>
+                                                   value="1" <?= checked(
+                                                   BackWPup_Option::get(
+                                                       $jobid,
+                                                       's3base_multipart'
+                                                   ), 1) ?>>
                                             <?php esc_html_e(
                                                 'Destination supports multipart',
                                                 'backwpup'
@@ -159,12 +158,11 @@ class BackWPup_Destination_S3 extends BackWPup_Destinations {
                                         <label
                                             for="s3base_pathstylebucket">
                                             <input name="s3base_pathstylebucket" type="checkbox"
-                                                   value="1" <?= !empty(
+                                                   value="1" <?= checked(
                                                    BackWPup_Option::get(
                                                        $jobid,
                                                        's3base_pathstylebucket'
-                                                   )
-                                                   ) ? 'checked="checked"' : '' ?>>
+                                                   ), 1) ?>>
                                             <?php esc_html_e(
                                                 'Destination provides only Pathstyle buckets',
                                                 'backwpup'
@@ -1110,10 +1108,10 @@ class BackWPup_Destination_S3 extends BackWPup_Destinations {
 						s3bucketselected: $( 'input[name="s3bucketselected"]' ).val(),
 						s3base_url      : $( 'input[name="s3base_url"]' ).val(),
 						s3region        : $( '#s3region' ).val(),
-						s3base_region          : $( 'input[name="s3base_region"]' ).val(),
-						s3base_version         : $( 'input[name="s3base_version"]' ).val(),
-						s3base_signature       : $( 'input[name="s3base_signature"]' ).val(),
-						s3base_multipart       : $( 'input[name="s3base_multipart"]' ).is(':checked'),
+						s3base_region      : $( 'input[name="s3base_region"]' ).val(),
+						s3base_version      : $( 'input[name="s3base_version"]' ).val(),
+						s3base_signature      : $( 'input[name="s3base_signature"]' ).val(),
+						s3base_multipart      : $( 'input[name="s3base_multipart"]' ).is(':checked'),
 						s3base_pathstylebucket : $( 'input[name="s3base_pathstylebucket"]' ).is(':checked'),
 						_ajax_nonce     : $( '#backwpupajaxnonce' ).val()
 					};

--- a/inc/class-s3-destination.php
+++ b/inc/class-s3-destination.php
@@ -165,9 +165,6 @@ class BackWPup_S3_Destination
                     'label' => __('Scaleway: AMS', 'backwpup'),
                     'endpoint' => 'https://s3.nl-ams.scw.cloud',
                 ],
-                'custom' => [
-                    'label' => __('Custom S3 destination', 'backwpup'),
-                ],
             ]
         );
     }

--- a/inc/class-s3-destination.php
+++ b/inc/class-s3-destination.php
@@ -165,6 +165,9 @@ class BackWPup_S3_Destination
                     'label' => __('Scaleway: AMS', 'backwpup'),
                     'endpoint' => 'https://s3.nl-ams.scw.cloud',
                 ],
+                'custom' => [
+                    'label' => __('Custom S3 destination', 'backwpup'),
+                ],
             ]
         );
     }
@@ -237,6 +240,7 @@ class BackWPup_S3_Destination
                 'verify' => BackWPup::get_plugin_data('cacert'),
             ],
             'version' => $this->version(),
+            'use_path_style_endpoint' => $this->onlyPathStyleBucket(),
         ];
 
         if ($this->endpoint()) {


### PR DESCRIPTION
Update #57, #60, #81, #116, #117

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

**What is the current behavior?** (You can also link to an open issue here)

Path style is not saved eventhough check the option since HTML is broken. Also path style option is not enabled to the S3 APIs.

**What is the new behavior (if this is a feature change)?**

Use `use_path_style_endpoint` for S3 API.
Path style is saved with check the option. Also path style option is enabled to the S3 APIs.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Now worked this plugin for S3 compatible servers. I checked this fix on minio, and Oracle Cloud.

**Other information**:
