### PR TITLE
Fix S3 backup list times shifted by the site's UTC offset (shown twice-offset in history tables)

### DIFF
--- a/inc/class-destination-s3.php
+++ b/inc/class-destination-s3.php
@@ -366,7 +366,7 @@ class BackWPup_Destination_S3 extends BackWPup_Destinations
         if (is_object($objects)) {
             foreach ($objects as $object) {
                 $file = basename((string) $object['Key']);
-                $changetime = strtotime((string) $object['LastModified']) + (get_option('gmt_offset') * 3600);
+                $changetime = strtotime((string) $object['LastModified']);
 
                 if ($this->is_backup_archive($file) && $this->is_backup_owned_by_job($file, $jobid)) {
                     $backupfilelist[$changetime] = $file;


### PR DESCRIPTION
Fixes #240

## Description

`BackWPup_Destination_S3::file_update_list()` converts the S3 object's `LastModified` (UTC) into a Unix timestamp and then adds the site's `gmt_offset`:

```php
$changetime = strtotime((string) $object['LastModified']) + (get_option('gmt_offset') * 3600);
```

Unix timestamps are timezone-independent, so this shifts the epoch value into the future for sites east of UTC.

All three consumers of this value format it with `wp_date()`, which already converts the epoch to the site timezone:

- the backups history table: `components/table-row-backups.php` (lines 9-10)
- the legacy backups page: `inc/class-page-backups.php` (`column_time()`)
- the S3 file list (download/restore view): `$files[$filecounter]['time']` within the same method, later rendered through `wp_date()`

The offset therefore gets applied twice. On a UTC+9 (Asia/Tokyo) site, every backup stored on an S3-compatible destination is displayed 9 hours in the future: a scheduled backup that ran at 0:00 JST shows as "9:00 AM", a manual backup taken at 1:40 PM shows as "10:40 PM". Backups stored on the local folder destination display correctly, which makes the S3 rows look inconsistent next to them.

## Fix

Drop the `gmt_offset` addition and keep the true epoch. This makes all three views show the correct backup time. It also brings S3 in line with the other remote destinations (Dropbox, MS Azure, RSC), which already use the raw epoch without an offset.

Retention pruning is unaffected: `$backupfilelist` is keyed by `$changetime` only for sorting, and removing a uniform shift does not change the ordering.

## How to reproduce

1. Set the site timezone to a non-UTC zone (e.g. Asia/Tokyo, UTC+9) in Settings → General.
2. Configure a job with an S3 (or S3-compatible, e.g. Cloudflare R2) destination and run it.
3. Open BackWPup → Backups History: the row shows the backup 9 hours in the future, while the filename (which uses site-local time) and a backup stored on the server show the correct time.

Tested on BackWPup 5.7.4 / WordPress with PHP 8.4 against Cloudflare R2 (S3-compatible).
